### PR TITLE
Add specific branch for SSL error handling for retrying

### DIFF
--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -518,6 +518,8 @@ class Pool(object):
                     if "SSL SYSCALL error:" in str(err):
                         log.warning("SSL SYSCALL failure so closing connection")
                         conn.close()
+                        future_set_exc_info(future, sys.exc_info())
+                        return
 
                     return self._retry(retry, when_available, conn, keep, future)
 

--- a/momoko/connection.py
+++ b/momoko/connection.py
@@ -513,8 +513,12 @@ class Pool(object):
             def when_done(rfut):
                 try:
                     result = rfut.result()
-                except psycopg2.Error:
+                except psycopg2.Error as err:
                     log.debug("Method failed Asynchronously")
+                    if "SSL SYSCALL error:" in str(err):
+                        log.warning("SSL SYSCALL failure so closing connection")
+                        conn.close()
+
                     return self._retry(retry, when_available, conn, keep, future)
 
                 future.set_result(result)


### PR DESCRIPTION
Attempting to handle the following error:

`SSL SYSCALL error: Connection timed out`

After connection, while `polling` the connection receives an SSL error. The branch of code this goes down never clears the connection so psycopg2 and results in the connection being in a bad state.
```
execute cannot be used while an asynchronous query is underway
```

The bad state is due to `async_cursor` remaining set on the connection while attempting to execute a new statement.